### PR TITLE
feat(v1.1): enforce 7-field audit template output contract

### DIFF
--- a/skills/agent-orchestrator/orchestrator.py
+++ b/skills/agent-orchestrator/orchestrator.py
@@ -358,8 +358,13 @@ def _build_audit_gate_payload(*, status: str, job_id: str, run_id: str, goal: st
     }
     required = ["status", "job_id", "run_id", "goal", "impact_scope", "risk_items", "command_preview", "user_instruction"]
     missing = [k for k in required if not str(payload.get(k, "")).strip()]
-    if missing:
-        raise RuntimeError(f"audit template invalid, missing fields: {','.join(missing)}")
+
+    # Hard rule: never send an audit message with missing fields.
+    # If a field is unavailable, mark UNKNOWN and keep the 7-item template intact.
+    for key in missing:
+        payload[key] = f"UNKNOWN (missing {key})"
+
+    payload["missing_fields"] = missing
     return payload
 
 

--- a/skills/agent-orchestrator/test_audit_template.py
+++ b/skills/agent-orchestrator/test_audit_template.py
@@ -1,0 +1,39 @@
+from orchestrator import _build_audit_gate_payload
+
+
+def test_audit_payload_keeps_required_fields():
+    payload = _build_audit_gate_payload(
+        status="awaiting_audit",
+        job_id="job_1",
+        run_id="run_1",
+        goal="demo",
+        impact_scope="scope",
+        risk_items="risk",
+        command_preview="cmd",
+        user_instruction="approve",
+    )
+
+    assert payload["status"] == "awaiting_audit"
+    assert payload["job_id"] == "job_1"
+    assert payload["run_id"] == "run_1"
+    assert payload["missing_fields"] == []
+
+
+def test_audit_payload_fills_unknown_for_missing_fields():
+    payload = _build_audit_gate_payload(
+        status="",
+        job_id="",
+        run_id="run_1",
+        goal="",
+        impact_scope="scope",
+        risk_items="",
+        command_preview="",
+        user_instruction="approve",
+    )
+
+    assert "status" in payload["missing_fields"]
+    assert payload["status"].startswith("UNKNOWN")
+    assert payload["job_id"].startswith("UNKNOWN")
+    assert payload["goal"].startswith("UNKNOWN")
+    assert payload["risk_items"].startswith("UNKNOWN")
+    assert payload["command_preview"].startswith("UNKNOWN")


### PR DESCRIPTION
Implements #28

- enforce 7-field audit template payload generation
- fill missing fields with UNKNOWN(reason) to avoid missing-item audit messages
- add unit tests for complete/missing-field cases

Closes #28