### PR TITLE
Issue #40: task artifact namespace isolation

### DIFF
--- a/skills/agent-orchestrator/m7/executor.py
+++ b/skills/agent-orchestrator/m7/executor.py
@@ -129,14 +129,18 @@ class Executor:
 
     def _expected_output_paths(self, task: dict) -> list[Path]:
         outputs = task.get("outputs", []) or []
+        task_id = str(task.get("id", "")).strip() or str(task.get("task_id", "")).strip()
         paths: list[Path] = []
         for raw in outputs:
             name = str(raw or "").strip()
             if not name:
                 continue
-            # Keep artifact exchange deterministic across agents.
+            # Keep artifact exchange deterministic across agents and isolate by task.
             fname = Path(name).name
-            paths.append(self.artifacts_dir / fname)
+            if task_id:
+                paths.append(self.artifacts_dir / task_id / fname)
+            else:
+                paths.append(self.artifacts_dir / fname)
         return paths
 
     def _validate_task_outputs(self, task: dict) -> tuple[bool, list[str]]:

--- a/skills/agent-orchestrator/m7/test_executor.py
+++ b/skills/agent-orchestrator/m7/test_executor.py
@@ -220,3 +220,12 @@ if __name__ == "__main__":
     test_executor_safe_wrapper_get_runnable_error()
     test_executor_safe_wrapper_start_task_error()
     test_executor_safe_wrapper_finish_task_error()
+
+
+def test_expected_output_paths_are_task_scoped(tmp_path):
+    ex = Executor(FakeScheduler([]), FakeAdapter([]), SessionWatcher(FakeAdapter([])), state_store=FakeStateStore(), artifacts_dir=str(tmp_path))
+    task = {"id": "task-40", "outputs": ["README.md", "output.json"]}
+    paths = ex._expected_output_paths(task)
+    assert str(paths[0]) == str(Path(tmp_path) / "task-40" / "README.md")
+    assert str(paths[1]) == str(Path(tmp_path) / "task-40" / "output.json")
+    print("✓ task-scoped artifact paths test passed")


### PR DESCRIPTION
Implements issue #40: outputs now written under issue/task-scoped artifact directories in Executor () and adds regression test for task-scoped output paths. This reduces output collisions across concurrent tasks.