### PR TITLE
fix(v1.2.2): context safety hotfixes for milestone 11

### DIFF
--- a/skills/agent-orchestrator/CONFIG.md
+++ b/skills/agent-orchestrator/CONFIG.md
@@ -122,6 +122,21 @@ Output validation defaults: non-empty output check and optional JSON schema chec
 - `ORCH_FAILURE_RETRY_TRANSIENT`, `ORCH_FAILURE_RETRY_LOGIC`: retry limits for classified failures.
 
 
+## v1.2.2 runtime contract
+
+- Issue #61: HMAC-signed task context
+  - `TASK_CONTEXT_HMAC_KEY`: when set, executor writes `context_sig` and enforces HMAC verification.
+  - Invalid/missing signature fails terminal commit with `CONTEXT_SIGNATURE_INVALID`.
+- Issue #62: Isolation hardening
+  - `ORCH_OUTPUT_ALLOW_IMPLICIT_AUTOMOVE` defaults to `0` (disabled).
+  - Cross-task implicit same-name artifact adoption is off by default.
+- Issue #63: Terminal protocol hardening
+  - Only strict marker lines are accepted (`[TASK_DONE]`, `[TASK_FAILED]`, `[TASK_WAITING] {"question":"..."}`).
+  - Non-schema payloads are rejected as malformed.
+- Issue #64: State machine hardening
+  - Executor validates context + outputs before success terminal commit.
+  - Terminal event is idempotent (`terminal-once`): no success→failed reversal.
+
 ## v1.2.1 runtime contract
 
 - Issue #55: Task context contract

--- a/skills/agent-orchestrator/README.md
+++ b/skills/agent-orchestrator/README.md
@@ -92,6 +92,7 @@ Release workflow for v1.2.0: run issues 40-44 in canary first, validate converge
 - Terminal events now use protocol v2 payload when compatibility mode enabled:
   - `task_completed` / `task_failed` / `task_waiting` include `status_protocol="v2"`, `terminal_state`, `failure` block and `retry_policy`.
 - Malformed terminal payloads are rejected: parser returns `MALFORMED_PAYLOAD` and executor marks task failed with actionable error.
+- v1.2.2 hardening: task context can be HMAC-signed (`TASK_CONTEXT_HMAC_KEY`), implicit cross-task artifact auto-move is disabled by default, and terminal commit is validate-first + terminal-once.
 - `TASK_WAITING` pauses only the task branch (`scheduler.pause_task`) and keeps unrelated runnable tasks flowing; task-level wait state is tracked for resume path.
 - Failure class and retryability are now attached to terminal errors (`failure_class`, `retryable`).
 - Canary + rollback support scripts added: `scripts/canary_gate.py`, `scripts/rollback_release.sh` for release-gate execution.

--- a/skills/agent-orchestrator/Runbook.md
+++ b/skills/agent-orchestrator/Runbook.md
@@ -82,4 +82,5 @@ python3 scripts/audit_timeline.py --job-id <job_id>
 
 - Canary validation: execute representative workflow on non-prod project_id and verify events/status convergence.
 - Rollback trigger: if canary fails acceptance, revert merge commits for v1.2.0 PRs and re-run smoke tests.
+- v1.2.2 canary checklist: verify `CONTEXT_SIGNATURE_INVALID` is raised for tampered context, verify malformed terminal payload yields `MALFORMED_PAYLOAD`, and confirm no implicit cross-task artifact auto-move occurs with default env.
 - Evidence artifacts: attach test_report.md, acceptance_evidence.md, and rollback dry-run notes.

--- a/skills/agent-orchestrator/m7/test_executor.py
+++ b/skills/agent-orchestrator/m7/test_executor.py
@@ -105,10 +105,10 @@ def _assert_std_error(err: dict):
 
 def test_parse_messages_markers():
     msgs = [
-        {"role": "assistant", "content": "ok [TASK_DONE]"},
-        {"role": "assistant", "content": "bad [TASK_FAILED]"},
-        {"role": "assistant", "content": "ask [TASK_WAITING] who are you?"},
-        {"role": "user", "content": "[TASK_DONE]"},
+        {"role": "assistant", "content": "[TASK_DONE]"},
+        {"role": "assistant", "content": "[TASK_FAILED]"},
+        {"role": "assistant", "content": "[TASK_WAITING] {\"question\": \"who are you?\"}"},
+        {"role": "assistant", "content": "noise [TASK_DONE]"},
     ]
     out = parse_messages(msgs)
     assert out == [
@@ -146,7 +146,7 @@ def test_executor_done_flow():
 def test_executor_waiting_flow():
     scheduler = FakeScheduler([[('agent_a', 't1')], []])
     adapter = FakeAdapter([
-        [{"role": "assistant", "content": "[TASK_WAITING] provide repo url"}],
+        [{"role": "assistant", "content": "[TASK_WAITING] {\"question\": \"provide repo url\"}"}],
     ])
     watcher = SessionWatcher(adapter)
     store = FakeStateStore()
@@ -270,4 +270,6 @@ def test_executor_task_context_tamper_rejects(tmp_path):
     data["task_id"] = "tampered"
     ctx_path.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
 
-    assert ex._validate_task_context("task-55") is False
+    ok, err = ex._validate_task_context("task-55")
+    assert ok is False
+    assert err in {"CONTEXT_HASH_MISMATCH", "CONTEXT_SIGNATURE_INVALID"}

--- a/skills/agent-orchestrator/utils/task_context_signature.py
+++ b/skills/agent-orchestrator/utils/task_context_signature.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from typing import Any
+
+
+def _canonical(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+
+
+def sign_task_context(payload: dict[str, Any], secret: str) -> str:
+    key = (secret or "").encode("utf-8")
+    return hmac.new(key, _canonical(payload), hashlib.sha256).hexdigest()
+
+
+def verify_task_context_signature(payload: dict[str, Any], signature: str, secret: str) -> bool:
+    expected = sign_task_context(payload, secret)
+    return hmac.compare_digest(expected, str(signature or ""))


### PR DESCRIPTION
## Summary
This PR delivers core milestone 11 context-safety hotfixes:
- HMAC signed task_context (TASK_CONTEXT_HMAC_KEY) + verification
- Disable implicit cross-task artifact auto-move by default
- Strict terminal marker payload parsing (schema-oriented)
- Validate-first + terminal-once executor state transition (prevents success->failed reversal)
- Runbook/config/readme updates for v1.2.2 canary checks

## Validation
- python3 -m pytest -q skills/agent-orchestrator/m7/test_executor.py

## Issues
Closes #61
Closes #62
Closes #63
Closes #64
Partially addresses #65