### PR TITLE
chore(release): add v1.2.2 canary benchmark rollback evidence

### DIFF
--- a/skills/agent-orchestrator/docs/release/v1.2.2-hotfix-evidence.md
+++ b/skills/agent-orchestrator/docs/release/v1.2.2-hotfix-evidence.md
@@ -1,0 +1,27 @@
+# v1.2.2 Context Safety Hotfix — Canary / Benchmark / Rollback Evidence
+
+Date: 2026-02-22
+
+## Canary validation
+- Scope: milestone 11 hotfix PR #72
+- Result: PASS (core hotfix tests green)
+
+## Benchmark snapshot
+Command:
+`python3 -m pytest -q skills/agent-orchestrator/m7/test_executor.py`
+
+Result:
+- `10 passed in 60.05s`
+- wall clock: `elapsed_seconds=60.47`
+
+## Rollback drill
+Command:
+`bash skills/agent-orchestrator/scripts/rollback_release.sh`
+
+Output:
+- `[ROLLBACK] noop rollback hook start`
+- `[ROLLBACK] preserving artifacts for inspection`
+
+## Notes
+- This release focuses on context-signature, output isolation default hardening, terminal parsing strictness, and validate-first terminal state machine behavior.
+- Follow-up release gate should include full-suite validation once notifier plugin environment is available.


### PR DESCRIPTION
## Summary
Add milestone 11 release evidence doc for canary/benchmark/rollback drill.

## Evidence
- 10 passed in 60.05s (m7/test_executor)
- rollback script drill output captured

## Issue
Closes #65