### PR TITLE
refactor(m5): AI-first agent assignment with soft routing guidance

### DIFF
--- a/skills/agent-orchestrator/m5/llm.py
+++ b/skills/agent-orchestrator/m5/llm.py
@@ -17,7 +17,9 @@ LLM_TIMEOUT = int(os.getenv("LLM_TIMEOUT", "60"))
 SYSTEM_PROMPT = (
     "You assign one task to one agent. Return JSON only with fields "
     "task_id, assigned_to, confidence, reason. "
-    "assigned_to must be one agent name from input. confidence must be 0..1."
+    "assigned_to must be one agent name from input. confidence must be 0..1. "
+    "Route primarily by agent capabilities. Treat routing_guidance and dependency_hints "
+    "as soft references, not hard constraints."
 )
 
 
@@ -30,10 +32,13 @@ def _strip_codeblock(text: str) -> str:
     return s.strip()
 
 
-def llm_assign(task: dict, agents: dict) -> dict:
+def llm_assign(task: dict, agents: dict, routing_guidance: dict | None = None) -> dict:
     user_prompt = (
         "agents_json:\n"
         + json.dumps(agents, ensure_ascii=False)
+        + "\n\n"
+        + "routing_guidance_json:\n"
+        + json.dumps(routing_guidance or {}, ensure_ascii=False)
         + "\n\n"
         + "task_json:\n"
         + json.dumps(task, ensure_ascii=False)

--- a/skills/agent-orchestrator/m5/routing_rules.json
+++ b/skills/agent-orchestrator/m5/routing_rules.json
@@ -1,35 +1,35 @@
 {
-  "version": "1.0",
-  "hard_rules": [
+  "version": "2.0",
+  "guidance": [
     {
-      "agent": "work",
-      "keywords": [
-        "github",
-        "pull request",
-        "pr",
-        "issue",
-        "milestone",
-        "release",
-        "repository",
-        "repo",
-        "github actions",
-        "workflow run",
-        "collect",
-        "fetch",
-        "status report"
+      "name": "capability-first-assignment",
+      "description": "Always assign by matching task intent to agent capabilities. Avoid keyword-only routing.",
+      "anti_patterns": [
+        "Do not route all GitHub-related tasks to one fixed agent.",
+        "Do not use one 'end-to-end' task to bypass implement/test/release separation."
       ]
     },
     {
-      "agent": "code",
-      "keywords": ["implement", "fix", "refactor", "patch", "code", "开发", "实现", "修复"]
+      "name": "implementation-testing-separation",
+      "description": "Implementation and testing should prefer different agents when both capabilities are available.",
+      "preferred_agents": ["code", "test"]
     },
     {
-      "agent": "test",
-      "keywords": ["test", "pytest", "regression", "ci", "验证", "回归"]
+      "name": "publish-risk-awareness",
+      "description": "Release/merge/close operations are high-risk. Prefer governance-capable agents and provide explicit rationale.",
+      "preferred_agents": ["main", "work"]
+    }
+  ],
+  "dependency_hints": [
+    {
+      "from": "implement",
+      "to": "test",
+      "reason": "Testing should validate implementation outputs."
     },
     {
-      "agent": "lab",
-      "keywords": ["browser", "twitter", "x.com", "web automation", "scrape"]
+      "from": "test",
+      "to": "release",
+      "reason": "Release should only happen after test evidence is available."
     }
   ]
 }

--- a/skills/agent-orchestrator/m5/test_assign_routing_rules.py
+++ b/skills/agent-orchestrator/m5/test_assign_routing_rules.py
@@ -6,23 +6,29 @@ def _reset_cache():
     assign_mod._AGENTS = None
 
 
-def test_github_hard_rule_routes_to_work():
+def test_ai_first_routing(monkeypatch):
     _reset_cache()
+
+    def fake_llm_assign(task, agents_data, routing_guidance):
+        return {"assigned_to": "code", "confidence": 0.91}
+
+    monkeypatch.setattr(assign_mod, "llm_assign", fake_llm_assign)
+
     tasks = {
         "tasks": [
             {"task_id": "t1", "title": "Create GitHub issue", "description": "open milestone issue"}
         ]
     }
     out = assign_mod.assign_agents(tasks)
-    assert out["tasks"][0]["assigned_to"] == "work"
-    assert out["tasks"][0]["routing_reason"] == "hard_rule:work"
+    assert out["tasks"][0]["assigned_to"] == "code"
+    assert out["tasks"][0]["routing_reason"].startswith("llm:")
 
 
-def test_llm_fallback_when_no_hard_rule(monkeypatch):
+def test_llm_fallback(monkeypatch):
     _reset_cache()
 
-    def fake_llm_assign(task, agents_data):
-        return {"assigned_to": "techwriter", "confidence": 0.88}
+    def fake_llm_assign(task, agents_data, routing_guidance):
+        raise RuntimeError("llm down")
 
     monkeypatch.setattr(assign_mod, "llm_assign", fake_llm_assign)
 
@@ -32,18 +38,18 @@ def test_llm_fallback_when_no_hard_rule(monkeypatch):
         ]
     }
     out = assign_mod.assign_agents(tasks)
-    assert out["tasks"][0]["assigned_to"] == "techwriter"
-    assert out["tasks"][0]["routing_reason"].startswith("llm:")
+    assert out["tasks"][0]["assigned_to"] == "main"
+    assert out["tasks"][0]["routing_reason"] == "fallback:llm_error"
 
 
-def test_invalid_routing_rule_agent_raises():
+def test_invalid_guidance_agent_raises():
     bad_rules = {
-        "version": "1.0",
-        "hard_rules": [{"agent": "nonexistent", "keywords": ["github"]}],
+        "version": "2.0",
+        "guidance": [{"name": "g1", "description": "d", "preferred_agents": ["nonexistent"]}],
     }
 
     try:
         assign_mod._validate_routing_rules(bad_rules, {"main", "work", "code", "test", "lab"})
         assert False, "Expected ValueError"
     except ValueError as e:
-        assert "not in agents.json" in str(e)
+        assert "unknown agent" in str(e)

--- a/skills/agent-orchestrator/schemas/routing_rules.schema.json
+++ b/skills/agent-orchestrator/schemas/routing_rules.schema.json
@@ -1,33 +1,64 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Orchestrator Routing Rules",
+  "title": "Orchestrator Routing Guidance",
   "type": "object",
-  "required": ["version", "hard_rules"],
+  "required": ["version"],
   "additionalProperties": false,
   "properties": {
     "version": {
       "type": "string",
       "minLength": 1
     },
-    "hard_rules": {
+    "guidance": {
       "type": "array",
-      "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["agent", "keywords"],
+        "required": ["name", "description"],
         "additionalProperties": false,
         "properties": {
-          "agent": {
+          "name": {
             "type": "string",
             "minLength": 1
           },
-          "keywords": {
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "preferred_agents": {
             "type": "array",
-            "minItems": 1,
             "items": {
               "type": "string",
               "minLength": 1
             }
+          },
+          "anti_patterns": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "dependency_hints": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["from", "to", "reason"],
+        "additionalProperties": false,
+        "properties": {
+          "from": {
+            "type": "string",
+            "minLength": 1
+          },
+          "to": {
+            "type": "string",
+            "minLength": 1
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1
           }
         }
       }


### PR DESCRIPTION
## Summary\n- Refactor m5 assignment to AI-first routing based on agent capabilities\n- Remove hard-coded keyword hard-rule routing\n- Convert routing_rules.json from hard_rules to soft guidance/dependency_hints\n- Pass routing guidance into LLM prompt as reference context\n- Update schema and m5 tests accordingly\n\n## Validation\n- python3 -m pytest -q m5/test_assign_routing_rules.py\n- Result: 3 passed\n\n## Scope\n- Only m5 assignment-related code and routing schema updated\n