### PR TITLE
feat(m2): task-type classification and mode-aware decomposition validation

### DIFF
--- a/skills/agent-orchestrator/m2/prompt.py
+++ b/skills/agent-orchestrator/m2/prompt.py
@@ -48,6 +48,10 @@ TASK GRANULARITY:
 Each task must be atomic - one agent completes it in one attempt.
 Target granularity: 2-10 minutes per task. If a task is larger, split it.
 
+TASK TYPE:
+- Include `task_type` for each task.
+- Allowed values: implement, test, integrate, docs, ops, research, coordination.
+
 GOOD: "Fetch HN homepage", "Parse top posts", "Write blog post"
 BAD: "Analyze HN", "Investigate", "Think about content"
 
@@ -99,7 +103,27 @@ EXAMPLE TASK:
 }
 """
 
+GOAL_CLASSIFIER_SYSTEM_PROMPT = """
+You are a task-type classifier for orchestration planning.
+Classify a goal into one of: coding, non_coding, mixed.
+
+Definitions:
+- coding: primary deliverable is source code changes and code verification.
+- non_coding: primary deliverable is docs/research/ops/coordination/content with no source code implementation required.
+- mixed: both coding and non-coding deliverables are core to completion.
+
+Return JSON only:
+{
+  "task_type": "coding|non_coding|mixed",
+  "confidence": 0.0-1.0,
+  "reason": "short rationale"
+}
+"""
+
 USER_PROMPT_TEMPLATE = "Goal: {goal}"
+CODING_USER_PROMPT_TEMPLATE = "Goal: {goal}\n\nPlanning mode: coding\nRequirements:\n- Include implement and test tasks (integrate optional by delivery need).\n- For coding tasks (implement/test/integrate), include non-empty tests[] and commands[].\n- Avoid single end-to-end mega task."
+NON_CODING_USER_PROMPT_TEMPLATE = "Goal: {goal}\n\nPlanning mode: non_coding\nRequirements:\n- Prefer docs/research/ops/coordination task types.\n- tests[] and commands[] are optional unless technically needed."
+MIXED_USER_PROMPT_TEMPLATE = "Goal: {goal}\n\nPlanning mode: mixed\nRequirements:\n- Split coding and non-coding work into separate tasks.\n- Coding tasks still require tests[] and commands[]."
 
 REPAIR_PROMPT_TEMPLATE = """
 The JSON you produced is invalid.

--- a/skills/agent-orchestrator/m2/validate.py
+++ b/skills/agent-orchestrator/m2/validate.py
@@ -4,11 +4,14 @@ from pathlib import Path
 
 SCHEMA_PATH = Path(__file__).parent.parent / "schemas" / "task.schema.json"
 
+
 def load_schema():
     with open(SCHEMA_PATH, "r") as f:
         return json.load(f)
 
+
 _validator = None
+
 
 def get_validator():
     global _validator
@@ -17,7 +20,47 @@ def get_validator():
         _validator = Draft202012Validator(schema)
     return _validator
 
-def validate_tasks(tasks_dict):
+
+def _is_coding_task(task: dict) -> bool:
+    t = str(task.get("task_type", "")).strip().lower()
+    return t in {"implement", "test", "integrate"}
+
+
+def _validate_coding_rules(tasks: list[dict]) -> None:
+    # Must have at least one explicit test task for coding decomposition
+    has_test_task = any(str(t.get("task_type", "")).strip().lower() == "test" for t in tasks)
+    if not has_test_task:
+        raise ValidationError("Coding decomposition must include at least one task_type='test' task")
+
+    task_ids = {str(t.get("id", "")).strip() for t in tasks}
+
+    for i, task in enumerate(tasks):
+        if not isinstance(task, dict):
+            continue
+        tt = str(task.get("task_type", "")).strip().lower()
+        if _is_coding_task(task):
+            tests = task.get("tests")
+            commands = task.get("commands")
+            if not isinstance(tests, list) or len(tests) == 0:
+                raise ValidationError(f"Task[{i}] coding task requires non-empty tests[]")
+            if not isinstance(commands, list) or len(commands) == 0:
+                raise ValidationError(f"Task[{i}] coding task requires non-empty commands[]")
+
+        # implement tasks should be validated by downstream test dependency
+        if tt == "implement":
+            tid = str(task.get("id", "")).strip()
+            covered = False
+            for other in tasks:
+                if str(other.get("task_type", "")).strip().lower() == "test":
+                    deps = other.get("deps") or []
+                    if tid in deps:
+                        covered = True
+                        break
+            if not covered and tid in task_ids:
+                raise ValidationError(f"Task[{i}] implement task must be covered by at least one test task dependency")
+
+
+def validate_tasks(tasks_dict, task_mode: str = "coding"):
     if not isinstance(tasks_dict, dict):
         raise ValidationError("Root must be object")
 
@@ -40,5 +83,9 @@ def validate_tasks(tasks_dict):
             validator.validate(task)
         except ValidationError as e:
             raise ValidationError(f"Task[{i}] invalid: {e.message}") from e
+
+    mode = str(task_mode or "coding").strip().lower()
+    if mode in {"coding", "mixed"}:
+        _validate_coding_rules(tasks_dict["tasks"])
 
     return True

--- a/skills/agent-orchestrator/schemas/task.schema.json
+++ b/skills/agent-orchestrator/schemas/task.schema.json
@@ -31,6 +31,12 @@
       "description": "Optional extra details for agent"
     },
 
+    "task_type": {
+      "type": "string",
+      "enum": ["implement", "test", "integrate", "docs", "ops", "research", "coordination"],
+      "description": "Semantic task type for decomposition and downstream routing"
+    },
+
     "status": {
       "type": "string",
       "enum": ["pending", "ready", "running", "waiting", "done", "failed"],
@@ -69,6 +75,18 @@
       "items": {
         "type": "string"
       }
+    },
+
+    "tests": {
+      "type": "array",
+      "description": "Test points or cases for coding tasks",
+      "items": {"type": "string"}
+    },
+
+    "commands": {
+      "type": "array",
+      "description": "Executable commands used for validation",
+      "items": {"type": "string"}
     },
 
     "assigned_to": {


### PR DESCRIPTION
## Summary\n- Add goal classifier in m2: coding / non_coding / mixed\n- Load mode-specific decomposition prompts\n- Extend task schema with task_type/tests/commands\n- Add mode-aware validation rules:\n  - coding/mixed require test tasks and tests/commands on coding tasks\n  - implement tasks must be covered by dependent test tasks\n- Update and expand m2 tests\n\n## Validation\n- python3 -m pytest -q skills/agent-orchestrator/m2/test_decompose.py\n- Result: 10 passed\n\n## Scope\n- m2 decomposition + schema only\n