### PR TITLE
feat(m17): observability, governance docs, validation activities and legacy proxy

### DIFF
--- a/skills/agent-orchestrator/CONFIG.md
+++ b/skills/agent-orchestrator/CONFIG.md
@@ -116,6 +116,8 @@ Output validation defaults: non-empty output check and optional JSON schema chec
 
 ## v1.2.0 runtime flags
 - `ORCH_TERMINAL_COMPAT` (`1`/`0`): allow legacy text protocol compatibility payload fields.
+- `ORCH_TRACE_ENABLED` (`1`/`0`): enable workflow/worker tracing hooks (OTel best-effort; LangSmith correlation hints).
+- `ORCH_LEGACY_QUEUE_COMPAT` (`1`/`0`): force `scripts/submit.py` to write legacy queue JSON instead of state-store proxy.
 - `ORCH_OUTPUT_VALIDATE_NON_EMPTY` (`1`/`0`): require outputs non-empty.
 - `ORCH_OUTPUT_VALIDATE_FRESHNESS` (`1`/`0`): require output file freshness within `ORCH_OUTPUT_MAX_AGE_MINUTES` (default 120).
 - `ORCH_OUTPUT_VALIDATE_JSON` (`1`/`0`): require `.json` outputs to be valid JSON.

--- a/skills/agent-orchestrator/README.md
+++ b/skills/agent-orchestrator/README.md
@@ -96,6 +96,8 @@ Release workflow for v1.2.0: run issues 40-44 in canary first, validate converge
 - `TASK_WAITING` pauses only the task branch (`scheduler.pause_task`) and keeps unrelated runnable tasks flowing; task-level wait state is tracked for resume path.
 - Failure class and retryability are now attached to terminal errors (`failure_class`, `retryable`).
 - Canary + rollback support scripts added: `scripts/canary_gate.py`, `scripts/rollback_release.sh` for release-gate execution.
+- M3 cutover docs: `docs/ADR-temporal-migration.md` and `docs/Runbook-temporal-cutover.md`.
+- Legacy submit entrypoint now defaults to compatibility proxy (StateStore path); set `ORCH_LEGACY_QUEUE_COMPAT=1` for temporary fallback.
 
 
 ## v1.2.1 runtime contract

--- a/skills/agent-orchestrator/docs/ADR-temporal-migration.md
+++ b/skills/agent-orchestrator/docs/ADR-temporal-migration.md
@@ -1,0 +1,23 @@
+# ADR: Temporal Migration (M3)
+
+## Status
+Accepted (v1.3.1 / milestone #17)
+
+## Context
+We migrated control-plane and run-level state to temporal-like runtime semantics, but validation and legacy operator commands still had mixed paths.
+
+## Decision
+1. Keep Temporal-oriented runtime as source of truth for run/task convergence.
+2. Keep legacy CLI entrypoints as **compatibility proxy** only (no direct state bypass in default mode).
+3. Move validation behavior into isolated activity modules (`workflow/validation_activities.py`) consumed by executor.
+4. Add tracing hooks for runner/worker signal handling to accelerate troubleshooting.
+
+## Consequences
+- Operators can continue using existing commands.
+- State mutation path is more auditable (signal enqueue -> worker apply -> events).
+- Validation is testable in isolation.
+
+## Rollback
+- Set `ORCH_RUN_BACKEND=legacy` to revert runtime backend behavior.
+- Set `ORCH_LEGACY_QUEUE_COMPAT=1` to temporarily route submit via legacy queue JSON.
+- If rollback is used, keep compatibility window short and log explicit rollback events.

--- a/skills/agent-orchestrator/docs/Runbook-temporal-cutover.md
+++ b/skills/agent-orchestrator/docs/Runbook-temporal-cutover.md
@@ -1,0 +1,32 @@
+# Runbook: Temporal Cutover / Rollback
+
+## Feature Flags
+- `ORCH_RUN_BACKEND=temporal|legacy`
+- `ORCH_LEGACY_QUEUE_COMPAT=0|1`
+- `ORCH_TRACE_ENABLED=0|1`
+
+## Cutover Checklist
+1. Ensure CI green (regression + control signal e2e).
+2. Deploy with `ORCH_RUN_BACKEND=temporal` and `ORCH_LEGACY_QUEUE_COMPAT=0`.
+3. Submit canary job via `scripts/submit.py` and confirm state transitions in `scripts/status.py`.
+4. Validate control flow:
+   - `scripts/control.py approve ...`
+   - `scripts/control.py resume ...`
+   - `scripts/control.py cancel ...`
+5. Verify events contain `control_signal_applied` and no direct bypass events.
+6. Confirm traces are emitted for runner/worker operations.
+
+## Rollback Drill
+1. Set `ORCH_RUN_BACKEND=legacy`.
+2. (Optional temporary) set `ORCH_LEGACY_QUEUE_COMPAT=1`.
+3. Re-run canary and compare status convergence.
+4. Record rollback start/end timestamps and reason in release evidence.
+
+## Acceptance Evidence Commands
+```bash
+pytest -q \
+  skills/agent-orchestrator/workflow/test_validation_activities.py \
+  skills/agent-orchestrator/scripts/test_control_signal_e2e.py \
+  skills/agent-orchestrator/scripts/test_worker_regression.py \
+  skills/agent-orchestrator/scripts/test_submit_proxy.py
+```

--- a/skills/agent-orchestrator/scripts/submit.py
+++ b/skills/agent-orchestrator/scripts/submit.py
@@ -2,8 +2,10 @@
 from __future__ import annotations
 
 import argparse
+import os
 
 from queue_lib import load_env, jobs_dir, new_job, atomic_write_json
+from state_store import StateStore
 
 
 def main() -> int:
@@ -13,9 +15,20 @@ def main() -> int:
     args = p.parse_args()
 
     load_env()
-    job = new_job(args.goal, project_id=args.project_id)
-    path = jobs_dir(args.project_id) / f"{job['job_id']}.json"
-    atomic_write_json(path, job)
+
+    # Legacy compatibility layer: keep old queue JSON path only when explicitly enabled.
+    # Default path proxies to StateStore/worker temporalized runtime.
+    legacy_mode = os.getenv("ORCH_LEGACY_QUEUE_COMPAT", "0").strip() == "1"
+    if legacy_mode:
+        job = new_job(args.goal, project_id=args.project_id)
+        path = jobs_dir(args.project_id) / f"{job['job_id']}.json"
+        atomic_write_json(path, job)
+        print(job["job_id"])
+        return 0
+
+    store = StateStore(args.project_id)
+    job = store.submit_job(args.goal)
+    store.add_event(job["job_id"], "legacy_submit_proxy", payload={"entrypoint": "scripts/submit.py", "mode": "state_store"})
     print(job["job_id"])
     return 0
 

--- a/skills/agent-orchestrator/scripts/test_submit_proxy.py
+++ b/skills/agent-orchestrator/scripts/test_submit_proxy.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from state_store import StateStore, load_env
+
+
+def test_submit_defaults_to_state_store_proxy(tmp_path):
+    os.environ["BASE_PATH"] = str(tmp_path)
+    os.environ["PROJECT_ID"] = "submit_proxy"
+    os.environ["ORCH_LEGACY_QUEUE_COMPAT"] = "0"
+    load_env()
+
+    root = Path(__file__).resolve().parent.parent
+    cp = subprocess.run([sys.executable, "scripts/submit.py", "demo goal"], cwd=root, text=True, capture_output=True, check=False)
+    assert cp.returncode == 0, cp.stderr
+    job_id = cp.stdout.strip()
+    assert job_id
+
+    store = StateStore("submit_proxy")
+    snap = store.get_job_snapshot(job_id)
+    assert snap is not None
+    events = [e.get("event") for e in (snap.get("events") or [])]
+    assert "legacy_submit_proxy" in events

--- a/skills/agent-orchestrator/utils/tracing.py
+++ b/skills/agent-orchestrator/utils/tracing.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import time
+from typing import Any, Iterator
+
+
+@contextlib.contextmanager
+def traced_span(name: str, **attrs: Any) -> Iterator[None]:
+    """Best-effort tracing span.
+
+    - If OpenTelemetry is installed and ORCH_TRACE_ENABLED=1, emit OTel span.
+    - If LangSmith is configured, expose run/task attrs as metadata via env hints.
+    - Otherwise fallback to no-op timing block.
+    """
+
+    enabled = os.getenv("ORCH_TRACE_ENABLED", "1").strip() != "0"
+    if not enabled:
+        yield
+        return
+
+    tracer = None
+    span = None
+    token = None
+    start = time.time()
+    try:
+        try:
+            from opentelemetry import trace  # type: ignore
+
+            tracer = trace.get_tracer("agent-orchestrator")
+            span = tracer.start_span(name)
+            token = trace.use_span(span, end_on_exit=False)
+            token.__enter__()
+            for k, v in attrs.items():
+                try:
+                    span.set_attribute(str(k), str(v))
+                except Exception:
+                    pass
+        except Exception:
+            tracer = None
+
+        # lightweight LangSmith correlation hints
+        if os.getenv("LANGSMITH_TRACING", "").strip().lower() in {"1", "true", "yes", "on"}:
+            if attrs.get("run_id"):
+                os.environ.setdefault("LANGSMITH_RUN_ID", str(attrs.get("run_id")))
+            if attrs.get("task_id"):
+                os.environ.setdefault("LANGSMITH_TASK_ID", str(attrs.get("task_id")))
+
+        yield
+        if span is not None:
+            span.set_attribute("status", "ok")
+    except Exception as e:
+        if span is not None:
+            try:
+                span.set_attribute("status", "error")
+                span.set_attribute("error", str(e))
+            except Exception:
+                pass
+        raise
+    finally:
+        if span is not None:
+            try:
+                span.set_attribute("duration_ms", int((time.time() - start) * 1000))
+            except Exception:
+                pass
+        if token is not None:
+            try:
+                token.__exit__(None, None, None)
+            except Exception:
+                pass
+        if span is not None:
+            try:
+                span.end()
+            except Exception:
+                pass

--- a/skills/agent-orchestrator/workflow/test_validation_activities.py
+++ b/skills/agent-orchestrator/workflow/test_validation_activities.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from workflow.validation_activities import validate_task_context_activity, validate_task_outputs_activity
+
+
+def test_validate_task_context_activity_ok(tmp_path):
+    p = tmp_path / "task_context.json"
+    p.write_text(json.dumps({"run_id": "r1", "task_id": "t1"}), encoding="utf-8")
+    ok, err = validate_task_context_activity(task_context_path=p, expected_run_id="r1", expected_task_id="t1")
+    assert ok is True
+    assert err is None
+
+
+def test_validate_task_outputs_activity_ok(tmp_path):
+    p = tmp_path / "out.json"
+    p.write_text(json.dumps({"ok": True}), encoding="utf-8")
+    ok, issues = validate_task_outputs_activity(
+        expected_paths=[p],
+        validate_non_empty=True,
+        validate_freshness=False,
+        output_max_age_min=10,
+        validate_json_schema=True,
+    )
+    assert ok is True
+    assert issues == []
+
+
+def test_validate_task_outputs_activity_missing(tmp_path):
+    p = tmp_path / "missing.txt"
+    ok, issues = validate_task_outputs_activity(
+        expected_paths=[p],
+        validate_non_empty=False,
+        validate_freshness=False,
+        output_max_age_min=10,
+        validate_json_schema=False,
+    )
+    assert ok is False
+    assert any(i.startswith("missing:") for i in issues)

--- a/skills/agent-orchestrator/workflow/validation_activities.py
+++ b/skills/agent-orchestrator/workflow/validation_activities.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+
+def validate_task_context_activity(*, task_context_path: Path, expected_run_id: str, expected_task_id: str) -> tuple[bool, str | None]:
+    try:
+        data = json.loads(task_context_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        return False, f"context_read_error:{e}"
+    if str(data.get("run_id") or "") != str(expected_run_id):
+        return False, "CONTEXT_RUN_ID_MISMATCH"
+    if str(data.get("task_id") or "") != str(expected_task_id):
+        return False, "CONTEXT_TASK_ID_MISMATCH"
+    return True, None
+
+
+def validate_task_outputs_activity(
+    *,
+    expected_paths: list[Path],
+    validate_non_empty: bool,
+    validate_freshness: bool,
+    output_max_age_min: int,
+    validate_json_schema: bool,
+) -> tuple[bool, list[str]]:
+    issues: list[str] = []
+    for p in expected_paths:
+        if not p.exists():
+            issues.append(f"missing:{p}")
+            continue
+        if validate_non_empty and p.stat().st_size == 0:
+            issues.append(f"empty:{p}")
+            continue
+        if validate_freshness:
+            age_minutes = (time.time() - p.stat().st_mtime) / 60
+            if age_minutes > output_max_age_min:
+                issues.append(f"stale:{p}")
+                continue
+        if validate_json_schema and p.suffix.lower() == ".json":
+            try:
+                json.loads(p.read_text(encoding="utf-8"))
+            except Exception as e:
+                issues.append(f"invalid_json:{p}:{e}")
+    return len(issues) == 0, issues


### PR DESCRIPTION
## Summary
Complete milestone #17 (M3) using GitHub flow (branch -> PR -> merge -> issue/milestone closure path).

### Requirement -> Files -> Evidence

1) #92 observability (workflow/activity trace hooks)
- Files:
  - `skills/agent-orchestrator/utils/tracing.py`
  - `skills/agent-orchestrator/scripts/runner.py`
  - `skills/agent-orchestrator/scripts/worker.py`
- Evidence:
  - trace spans added for run goal + control signal application + worker execution path

2) #93 validation activities refactor
- Files:
  - `skills/agent-orchestrator/workflow/validation_activities.py`
  - `skills/agent-orchestrator/m7/executor.py`
  - `skills/agent-orchestrator/workflow/test_validation_activities.py`
- Evidence:
  - validation path in executor done-branch calls activity module API
  - tests pass

3) #94 ADR + cutover/rollback runbook
- Files:
  - `skills/agent-orchestrator/docs/ADR-temporal-migration.md`
  - `skills/agent-orchestrator/docs/Runbook-temporal-cutover.md`
- Evidence:
  - cutover checklist + rollback drill + flag strategy documented

4) #95 legacy compatibility proxy layer
- Files:
  - `skills/agent-orchestrator/scripts/submit.py`
  - `skills/agent-orchestrator/scripts/test_submit_proxy.py`
- Evidence:
  - default submit path goes through StateStore proxy
  - fallback path guarded by `ORCH_LEGACY_QUEUE_COMPAT=1`

## Repro Validation Commands
```bash
pytest -q \
  skills/agent-orchestrator/workflow/test_validation_activities.py \
  skills/agent-orchestrator/scripts/test_submit_proxy.py \
  skills/agent-orchestrator/scripts/test_control_signal_e2e.py \
  skills/agent-orchestrator/scripts/test_worker_regression.py
```
Result: 7 passed

## Control-plane bypass note
- Default path avoids direct legacy queue state as source-of-truth.
- Compatibility path remains only behind explicit flag (`ORCH_LEGACY_QUEUE_COMPAT=1`) for temporary rollback window.

Refs: #92 #93 #94 #95
