### PR TITLE
feat(m20): close #127/#128 with executable release-gate path and CI smoke gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,34 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt pytest
 
-      - name: Run critical regression tests (#6)
+      - name: Run critical regression tests (expanded)
         run: |
           pytest -q \
             test_orchestrate_pipeline.py \
-            scripts/test_worker_regression.py
+            scripts/test_worker_regression.py \
+            scripts/test_control_signal_e2e.py \
+            scripts/test_control_temporal_signals.py \
+            scripts/test_p1_regression_suite.py \
+            scripts/test_release_gate_check.py \
+            scripts/test_slo_gate.py \
+            scripts/test_canary_rollout.py
+
+      - name: Run release gate smoke (healthy should pass)
+        run: |
+          python3 scripts/release_gate_check.py \
+            --project-id ci_gate_ok \
+            --metrics-json '{"stalled_rate":0.01,"resume_success_rate":0.995,"terminal_once_violation":0,"stalled_rate_rebound":0.0,"terminal_reversal":0,"resume_failure_spike":0.0}' \
+            --min-stage-hours 0 \
+            --fail-on-block
+
+      - name: Run release gate smoke (redline should block)
+        run: |
+          set +e
+          python3 scripts/release_gate_check.py \
+            --project-id ci_gate_block \
+            --metrics-json '{"stalled_rate":0.01,"resume_success_rate":0.995,"terminal_once_violation":0,"stalled_rate_rebound":0.06,"terminal_reversal":0,"resume_failure_spike":0.0}' \
+            --min-stage-hours 0 \
+            --fail-on-block
+          RC=$?
+          set -e
+          test "$RC" -eq 1

--- a/skills/agent-orchestrator/scripts/release_gate_check.py
+++ b/skills/agent-orchestrator/scripts/release_gate_check.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+
+from canary_rollout import evaluate_rollout
+from slo_gate import evaluate_slo
+from state_store import load_env, resolve_project_id
+
+
+def evaluate_release_gate(project_id: str, metrics: dict, min_stage_hours: int = 48) -> dict:
+    canary = evaluate_rollout(project_id, metrics, min_stage_hours=min_stage_hours)
+    slo = evaluate_slo(
+        {
+            "stalled_rate": float(metrics.get("stalled_rate", 0.0)),
+            "resume_success_rate": float(metrics.get("resume_success_rate", 0.0)),
+            "terminal_once_violation": int(metrics.get("terminal_once_violation", 0)),
+        }
+    )
+
+    blocked = False
+    reasons: list[str] = []
+    if canary.get("decision", {}).get("action") == "rollback":
+        blocked = True
+        reasons.append("canary_redline_triggered")
+    if not slo.get("pass", False):
+        blocked = True
+        reasons.append("slo_gate_failed")
+
+    return {
+        "project_id": project_id,
+        "blocked": blocked,
+        "reasons": reasons,
+        "canary": canary,
+        "slo": slo,
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Evaluate release gate from canary + SLO")
+    p.add_argument("--project-id", default=None)
+    p.add_argument("--metrics-json", required=True)
+    p.add_argument("--min-stage-hours", type=int, default=48)
+    p.add_argument("--fail-on-block", action="store_true")
+    args = p.parse_args()
+
+    load_env()
+    project_id = resolve_project_id(args.project_id)
+    metrics = json.loads(args.metrics_json)
+    result = evaluate_release_gate(project_id, metrics, min_stage_hours=args.min_stage_hours)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if args.fail_on_block and result.get("blocked"):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/agent-orchestrator/scripts/test_release_gate_check.py
+++ b/skills/agent-orchestrator/scripts/test_release_gate_check.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from release_gate_check import evaluate_release_gate
+
+
+def test_release_gate_allows_healthy_metrics(tmp_path, monkeypatch):
+    monkeypatch.setenv("BASE_PATH", str(tmp_path))
+    monkeypatch.setenv("PROJECT_ID", "gate_ok")
+    out = evaluate_release_gate(
+        "gate_ok",
+        {
+            "stalled_rate": 0.01,
+            "resume_success_rate": 0.995,
+            "terminal_once_violation": 0,
+            "stalled_rate_rebound": 0.0,
+            "terminal_reversal": 0,
+            "resume_failure_spike": 0.0,
+        },
+        min_stage_hours=0,
+    )
+    assert out["blocked"] is False
+
+
+def test_release_gate_blocks_redline(tmp_path, monkeypatch):
+    monkeypatch.setenv("BASE_PATH", str(tmp_path))
+    monkeypatch.setenv("PROJECT_ID", "gate_bad")
+    out = evaluate_release_gate(
+        "gate_bad",
+        {
+            "stalled_rate": 0.01,
+            "resume_success_rate": 0.995,
+            "terminal_once_violation": 0,
+            "stalled_rate_rebound": 0.06,
+            "terminal_reversal": 0,
+            "resume_failure_spike": 0.0,
+        },
+        min_stage_hours=0,
+    )
+    assert out["blocked"] is True
+    assert "canary_redline_triggered" in out["reasons"]


### PR DESCRIPTION
## Summary
Follow-up closure work for milestone-20 audit gaps on #127/#128.

This PR adds an executable release-gate path (not only helper functions) and CI smoke checks to prevent regression.

## What is added
1. `scripts/release_gate_check.py`
   - Combines canary decision + SLO gate into one release-gate decision
   - Supports `--fail-on-block` for CI enforcement
   - Outputs auditable JSON decision payload

2. `scripts/test_release_gate_check.py`
   - Covers healthy allow path and redline block path

3. CI enhancement in `.github/workflows/ci.yml`
   - Expands critical regression test scope
   - Adds release-gate smoke (healthy must pass)
   - Adds release-gate smoke (redline must block, asserts exit=1)

## Local verification
```bash
python3 -m pytest -q \
  skills/agent-orchestrator/scripts/test_release_gate_check.py \
  skills/agent-orchestrator/scripts/test_canary_rollout.py \
  skills/agent-orchestrator/scripts/test_slo_gate.py \
  skills/agent-orchestrator/scripts/test_worker_regression.py \
  skills/agent-orchestrator/scripts/test_control_signal_e2e.py \
  skills/agent-orchestrator/scripts/test_control_temporal_signals.py \
  skills/agent-orchestrator/scripts/test_p1_regression_suite.py
# 13 passed

python3 skills/agent-orchestrator/scripts/release_gate_check.py \
  --project-id local_gate_ok \
  --metrics-json '{"stalled_rate":0.01,"resume_success_rate":0.995,"terminal_once_violation":0,"stalled_rate_rebound":0.0,"terminal_reversal":0,"resume_failure_spike":0.0}' \
  --min-stage-hours 0 --fail-on-block
# pass

python3 skills/agent-orchestrator/scripts/release_gate_check.py \
  --project-id local_gate_bad \
  --metrics-json '{"stalled_rate":0.01,"resume_success_rate":0.995,"terminal_once_violation":0,"stalled_rate_rebound":0.06,"terminal_reversal":0,"resume_failure_spike":0.0}' \
  --min-stage-hours 0 --fail-on-block
# exits 1 (expected)
```

Refs #127
Refs #128
